### PR TITLE
add a rule for enforcing newline before a return

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,10 +7,13 @@
 
 'use strict';
 
-/* As of a first version, we only extend the config of
- * eslint-config-react-app as it serves most of our cases.
- * We might however overwrite or add rules later.
- */
 module.exports = {
-  extends: ['react-app']
+  extends: ['react-app'],
+  rules: {
+    'padding-line-between-statements': [
+      'error',
+      // Always require blank lines before return statements
+      { blankLine: 'always', prev: '*', next: 'return' }
+    ]
+  }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-guestline",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "ESLint configuration used by Guestline",
   "repository": "guestlinelabs/scripts",
   "license": "MIT",


### PR DESCRIPTION
I see that we usually ask in our PRs to put newlines before a return statement, so why not make it a rule? :)